### PR TITLE
Add clarification about re-adding agent label after responding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Fargate container that runs Claude Code on GitHub issues/PRs.
 **Operator Note**: The `agent` label is a trigger label that activates the GitHub agent. The agent's current state is shown separately through status labels:
 
 - `agent:running` - Agent is currently processing the issue/PR
-- `agent:waiting` - Agent is waiting for additional input or clarification
+- `agent:waiting` - Agent is waiting for additional input or clarification (requires a human to re-add the `agent` label after responding)
 - `agent:failed` - Agent encountered an error and could not complete the task
 
 To activate the agent on an issue or PR, simply add the `agent` label. To resume a waiting agent, re-add the `agent` label after providing the requested clarification.


### PR DESCRIPTION
Fixes #12

This PR adds a clarification to the README.md noting that the waiting state requires a human to re-add the `agent` label after responding.

## Changes
- Updated the `agent:waiting` status description to explicitly mention that a human must re-add the `agent` label after providing response/clarification
- This addresses potential confusion about how to resume waiting agents