### PR TITLE
fix: default failure_category param in entrypoint to prevent unbound variable error

### DIFF
--- a/agent/entrypoint.sh
+++ b/agent/entrypoint.sh
@@ -76,7 +76,7 @@ update_task_metadata() {
   local status="$1"
   local error_message="$2"
   local pr_url="$3"
-  local failure_category="$4"
+  local failure_category="${4:-}"
   local completed_timestamp=""
 
   if [ "$status" != "running" ]; then


### PR DESCRIPTION
## Summary

- Defaults the `failure_category` parameter in `update_task_metadata()` to an empty string (`${4:-}`) when not provided, preventing an unbound variable error under `set -u`.
- 3 out of 4 call sites only pass 3 arguments, triggering the error.

Fixes #108
Fixes #111

## Test plan

- [ ] Verify `agent:failed` errors no longer occur when `update_task_metadata` is called with 3 arguments
- [ ] Confirm the single call site that passes 4 arguments still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)