### PR TITLE
fix: add review agent Docker build + narrow protected paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,3 +51,12 @@ jobs:
           docker tag ${{ env.ECR_REPO }}:latest ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPO }}:${{ github.sha }}
           docker push ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPO }}:latest
           docker push ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPO }}:${{ github.sha }}
+
+      - name: Build and push review agent image
+        run: |
+          cd agent
+          docker build --platform linux/amd64 -f Dockerfile.review -t github-agent-review .
+          docker tag github-agent-review:latest ${{ steps.ecr-login.outputs.registry }}/github-agent-review:latest
+          docker tag github-agent-review:latest ${{ steps.ecr-login.outputs.registry }}/github-agent-review:${{ github.sha }}
+          docker push ${{ steps.ecr-login.outputs.registry }}/github-agent-review:latest
+          docker push ${{ steps.ecr-login.outputs.registry }}/github-agent-review:${{ github.sha }}


### PR DESCRIPTION
## Summary
- **Deploy workflow fix (#84)**: Add review agent Docker image build step to `deploy.yml` so the review container is actually pushed to ECR
- **Protected paths fix (#190)**: Replace blanket `infra/` entry in `PROTECTED_PATHS` with specific critical paths (`infra/lib/stack.ts`, `infra/bin/`, `infra/cdk.json`) so handler/type PRs can be auto-reviewed instead of all being flagged `review:human-required`

## Impact
- Unblocks 7+ PRs currently stuck with `review:human-required` label due to overly broad path matching
- Ensures review agent container is built and deployed alongside the main agent container

## Test plan
- [ ] Verify deploy workflow builds both agent images
- [ ] Verify PRs touching `infra/lib/review-handler.ts` or `infra/lib/types.ts` are no longer blocked
- [ ] Verify PRs touching `infra/lib/stack.ts` or `.github/workflows/` are still flagged for human review

https://claude.ai/code/session_01Q2YoNTRiqDCQSfkpDmEv7X