### PR TITLE
fix: prevent duplicate PRs — check for existing agent PR before creating new one

### DIFF
--- a/agent/entrypoint.sh
+++ b/agent/entrypoint.sh
@@ -422,6 +422,22 @@ should_post_comment() {
   return 0  # Should post
 }
 
+# Check if there is already an open PR created by the agent for this issue
+check_for_existing_agent_pr() {
+  # Only relevant for issue tasks — PRs don't create new PRs
+  if [ "${IS_PR}" = "true" ]; then
+    return
+  fi
+
+  local pr_number
+  pr_number=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
+    --jq "[.[] | select(.body != null) | select(.body | test(\"(Fixes|Closes|Resolves) #${ISSUE_NUMBER}(\\\\b|$)\")) | .number] | first // empty" 2>/dev/null) || true
+
+  if [ -n "${pr_number}" ]; then
+    echo "${pr_number}"
+  fi
+}
+
 # --- Auth gh CLI ---
 CURRENT_STAGE="authenticate GitHub CLI"
 if ! setup_github_auth "${REPO}"; then
@@ -859,6 +875,21 @@ Your mission:
 
 When you close the issue, the system will detect this and mark your work as complete."
 else
+  # Check for an existing agent PR that already references this issue
+  EXISTING_PR_NUMBER=$(check_for_existing_agent_pr || true)
+  EXISTING_PR_NOTE=""
+  if [ -n "${EXISTING_PR_NUMBER}" ]; then
+    echo "WARNING: Found existing open PR #${EXISTING_PR_NUMBER} referencing issue #${ISSUE_NUMBER}"
+    EXISTING_PR_NOTE="
+
+IMPORTANT — EXISTING PR DETECTED:
+There is already an open PR #${EXISTING_PR_NUMBER} that references this issue.
+Before creating a new PR, review PR #${EXISTING_PR_NUMBER} to understand what has already been done.
+If the existing PR adequately addresses the issue, do NOT create a duplicate.
+Instead, post a comment on this issue explaining that PR #${EXISTING_PR_NUMBER} already addresses it.
+Only create a new PR if the existing one is fundamentally broken or takes a wrong approach."
+  fi
+
   MISSION="${SYSTEM_INSTRUCTIONS}${FEEDBACK_SECTION}
 
 ---
@@ -868,7 +899,7 @@ TASK (from issue #${ISSUE_NUMBER}):
 You have been triggered by the 'agent' label on issue #${ISSUE_NUMBER} in ${REPO}.
 
 Here is the issue context:
-${CONTEXT}
+${CONTEXT}${EXISTING_PR_NOTE}
 
 Your mission:
 - Understand the issue and explore the codebase to find the relevant files

--- a/infra/lib/webhook-handler.ts
+++ b/infra/lib/webhook-handler.ts
@@ -2729,6 +2729,65 @@ This production deployment failure has been automatically escalated. The agent w
   }
 }
 
+/**
+ * Check if there is already an active (running) task for a given issue.
+ * Returns true if an active task is found, false otherwise.
+ * On error, returns false so we don't block launches.
+ */
+async function checkForActiveTasks(
+  repoSlug: string,
+  issueNumber: number
+): Promise<boolean> {
+  try {
+    const prefix = `tasks/${repoSlug}/`;
+    const listResult = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: ARTIFACTS_BUCKET,
+        Prefix: prefix,
+        MaxKeys: 200,
+      })
+    );
+
+    const contents = listResult.Contents || [];
+    const metadataKeys = contents
+      .map((obj) => obj.Key!)
+      .filter((key) => key.endsWith("/metadata.json"));
+
+    for (const key of metadataKeys) {
+      try {
+        const result = await s3.send(
+          new GetObjectCommand({
+            Bucket: ARTIFACTS_BUCKET,
+            Key: key,
+          })
+        );
+        const body = await result.Body!.transformToString();
+        const metadata = JSON.parse(body);
+
+        if (
+          metadata.issue_number === issueNumber &&
+          metadata.status === "running"
+        ) {
+          console.log(
+            `Found active task for issue #${issueNumber}: ${key}`
+          );
+          return true;
+        }
+      } catch {
+        // Skip unreadable metadata files
+        continue;
+      }
+    }
+
+    return false;
+  } catch (error) {
+    console.error(
+      `Error checking for active tasks (non-blocking): ${error}`
+    );
+    return false;
+  }
+}
+
 export async function handler(event: {
   headers: Record<string, string | undefined>;
   body?: string;
@@ -3555,6 +3614,13 @@ export async function handler(event: {
     return { statusCode: 200, body: "Already running" };
   }
 
+  // --- Check for active tasks in S3 metadata ---
+  const repoSlug = createRepoSlug(repoOwner, repoName);
+  if (await checkForActiveTasks(repoSlug, issueNumber)) {
+    console.log(`Issue #${issueNumber} has an active task in S3, skipping`);
+    return { statusCode: 200, body: "Already running (active task found)" };
+  }
+
   await ensureSignalLabels(repoOwner, repoName, githubToken);
   await setSignalLabel(
     repoOwner,
@@ -3578,7 +3644,6 @@ export async function handler(event: {
 
   // --- Create task payload ---
   const taskId = generateTaskId();
-  const repoSlug = createRepoSlug(repoOwner, repoName);
 
   // Extract label names from the webhook payload
   const labels = isPR


### PR DESCRIPTION
Replaces #187 (rebased onto current main after #202 unification refactor)

Fixes #182

## Summary
Two-layer deduplication to prevent duplicate PRs when multiple concurrent agent tasks run for the same issue.

1. **Webhook handler**: `checkForActiveTasks()` checks S3 metadata for running tasks before launching Fargate
2. **Entrypoint**: `check_for_existing_agent_pr()` searches for open PRs referencing the issue and warns the agent

## Test plan
- [ ] Duplicate agent label triggers are rejected at webhook level
- [ ] Agent detects existing open PR and avoids creating duplicate
- [ ] S3 metadata correctly tracks active running tasks

https://claude.ai/code/session_01Q2YoNTRiqDCQSfkpDmEv7X