### PR TITLE
fix: remove standalone output for Amplify compatibility

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: 'standalone',
-}
+const nextConfig = {}
 
 module.exports = nextConfig


### PR DESCRIPTION
Follow-up to #244 — remove `output: 'standalone'` from next.config.js which conflicts with Amplify's WEB_COMPUTE deploy manifest generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)