### PR TITLE
fix: add concurrency control to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-main
+  cancel-in-progress: true
+
 env:
   AWS_REGION: us-east-1
   ECR_REPO: github-agent


### PR DESCRIPTION
## Summary
Adds a top-level `concurrency` block to `.github/workflows/deploy.yml` to prevent CloudFormation conflicts when rapid consecutive pushes to main trigger overlapping deploys.

```yaml
concurrency:
  group: deploy-main
  cancel-in-progress: true
```

## Why this is being done by hand (not the agent)
The agent successfully implemented this fix on 2026-04-05 but couldn't push because the GitHub App lacks the `workflows` permission scope (see #304 history). This PR was opened directly by the maintainer so the fix can land while the App permission is sorted out.

## Acceptance criteria
- [x] Concurrency block added to deploy.yml
- [ ] Rapid consecutive pushes no longer cause CloudFormation conflicts (verify after merge)
- [x] Only the latest deploy runs to completion

## Follow-up
Open a separate issue to grant the GitHub App `workflows: write` so the agent can self-service workflow file edits in future.

Fixes #304