### PR TITLE
fix(webhook): debounce workflow-failure mirror issues

### DIFF
--- a/infra/lib/webhook-handler.ts
+++ b/infra/lib/webhook-handler.ts
@@ -2614,27 +2614,35 @@ async function launchDiagnosticFargateTask(
 }
 
 /**
- * Checks if a workflow failure issue already exists for this workflow run
+ * Checks if a workflow failure issue already exists for this workflow.
+ *
+ * Searches both open and closed issues. A closed match means the workflow is
+ * failing again after being previously marked resolved — the caller should
+ * reopen + comment rather than create a duplicate.
+ *
+ * Matches on the literal auto-generated title prefix, so unrelated bug
+ * issues that happen to mention the workflow name are not picked up.
  */
 async function checkExistingWorkflowFailureIssue(
   repoOwner: string,
   repoName: string,
   workflowName: string,
   token: string
-): Promise<number | null> {
+): Promise<{ number: number; state: "open" | "closed" } | null> {
   try {
-    // Search for open issues with specific label pattern and title
-    const query = `repo:${repoOwner}/${repoName} is:issue is:open label:type:bug "${workflowName}" workflow`;
-    const response = await fetch(
-      `https://api.github.com/search/issues?q=${encodeURIComponent(query)}&per_page=5`,
-      {
-        headers: {
-          Accept: "application/vnd.github+json",
-          Authorization: `Bearer ${token}`,
-          "User-Agent": "github-agent-control-plane",
-        },
-      }
-    );
+    // Match the auto-generated title prefix literally and sort by most-recent
+    // update, so we always return the latest matching mirror issue regardless
+    // of whether it was closed manually.
+    const titleMatch = `🚨 Deploy Workflow Failed: ${workflowName}`;
+    const query = `repo:${repoOwner}/${repoName} is:issue in:title "${titleMatch}"`;
+    const url = `https://api.github.com/search/issues?q=${encodeURIComponent(query)}&per_page=5&sort=updated&order=desc`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "github-agent-control-plane",
+      },
+    });
 
     if (!response.ok) {
       console.warn(`Failed to search for existing issues: ${response.status}`);
@@ -2643,14 +2651,45 @@ async function checkExistingWorkflowFailureIssue(
 
     const data = await response.json() as any;
     if (data.items && data.items.length > 0) {
-      console.log(`Found ${data.items.length} existing workflow failure issue(s)`);
-      return data.items[0].number;
+      const top = data.items[0];
+      const state: "open" | "closed" = top.state === "closed" ? "closed" : "open";
+      console.log(
+        `Found ${data.items.length} existing workflow failure issue(s); latest #${top.number} is ${state}`
+      );
+      return { number: top.number, state };
     }
 
     return null;
   } catch (error) {
     console.warn(`Failed to check for existing workflow issue: ${error}`);
     return null;
+  }
+}
+
+/**
+ * Reopens a previously-closed issue. Used when a workflow that was marked
+ * resolved starts failing again — we reopen the mirror rather than create a
+ * duplicate.
+ */
+async function reopenIssue(
+  repoOwner: string,
+  repoName: string,
+  issueNumber: number,
+  token: string
+): Promise<void> {
+  try {
+    await githubRequest(
+      `/repos/${repoOwner}/${repoName}/issues/${issueNumber}`,
+      token,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ state: "open" }),
+      },
+      [200]
+    );
+    console.log(`Reopened issue #${issueNumber}`);
+  } catch (error) {
+    console.warn(`Failed to reopen issue #${issueNumber}: ${error}`);
   }
 }
 
@@ -2769,16 +2808,20 @@ async function handleWorkflowRunFailure(
       `Handling workflow failure: ${workflowName} (run #${workflowRunId}) in ${repoSlug}`
     );
 
-    // Check if an issue already exists for this workflow
-    const existingIssueNumber = await checkExistingWorkflowFailureIssue(
+    // Check if an issue already exists for this workflow — in either state.
+    // A closed match means the workflow is failing again after being marked
+    // resolved; reopen + comment instead of spawning a duplicate mirror.
+    const existing = await checkExistingWorkflowFailureIssue(
       repoOwner,
       repoName,
       workflowName,
       token
     );
 
-    if (existingIssueNumber) {
-      console.log(`Found existing issue #${existingIssueNumber} for workflow failure`);
+    if (existing) {
+      console.log(
+        `Found existing issue #${existing.number} (${existing.state}) for workflow failure`
+      );
 
       // Update the existing issue with new failure information
       const errorMessages = await extractWorkflowErrorMessages(
@@ -2789,6 +2832,11 @@ async function handleWorkflowRunFailure(
         failedJobName
       );
 
+      const reopenedBanner =
+        existing.state === "closed"
+          ? "\n\n> ⚠️ This issue was previously closed but the workflow is failing again — reopened automatically."
+          : "";
+
       const updateComment = `## Workflow Failure Detected (Run #${workflowRunId})
 
 **Workflow:** [${workflowName}](${workflowRunUrl})
@@ -2797,10 +2845,13 @@ async function handleWorkflowRunFailure(
 
 **Failed Job:** ${failedJobName}
 
-${errorMessages}`;
+${errorMessages}${reopenedBanner}`;
 
-      await addIssueComment(repoOwner, repoName, existingIssueNumber, token, updateComment);
-      console.log(`Updated existing issue #${existingIssueNumber} with new failure`);
+      if (existing.state === "closed") {
+        await reopenIssue(repoOwner, repoName, existing.number, token);
+      }
+      await addIssueComment(repoOwner, repoName, existing.number, token, updateComment);
+      console.log(`Updated existing issue #${existing.number} with new failure`);
       return;
     }
 


### PR DESCRIPTION
## Summary

The deploy-monitoring webhook (`handleWorkflowRunFailure`) has been creating a new GitHub issue for **every** transient deploy failure, because `checkExistingWorkflowFailureIssue` restricted its search to `is:open` issues. Once someone manually closes the mirror for a transient failure (which is the natural housekeeping move), the next failure finds no open match → spawns a duplicate.

In `cenetex/aws-swarm` alone we've accumulated: #1234, #1267, #1304, #1305, #1310, #1350, #1396, #1398, #1404 — all the same kind.

## Changes

1. **Drop the `is:open` filter** and sort by most-recently updated so we always find the latest mirror regardless of state.
2. **Tighten the query to a literal title prefix** (`🚨 Deploy Workflow Failed: <workflowName>`) — unrelated `type:bug` issues that happen to mention the workflow name no longer match.
3. **Return `{number, state}`** instead of just the number.
4. **Reopen closed matches** via `PATCH /issues/{n}` with `state=open` before commenting. The new comment includes a banner noting the auto-reopen so reviewers understand why a previously-closed issue is alive again.

## Behaviour summary

| Prior state of latest match | Before | After |
|---|---|---|
| Open | Comment on it ✅ | Comment on it ✅ (unchanged) |
| Closed | Create a new issue ❌ | **Reopen + comment** ✅ |
| No match | Create a new issue ✅ | Create a new issue ✅ (unchanged) |

## Test plan

- [x] Local typecheck passes (`cd infra && npx tsc --noEmit`)
- [ ] CI typecheck / build passes
- [ ] Post-deploy manual test: trigger a workflow failure in a test repo, verify only one mirror is created
- [ ] Post-deploy manual test: close the mirror, trigger another failure, verify the same issue is reopened with a new comment
- [ ] Post-deploy manual test: verify unrelated open `type:bug` issues mentioning the workflow name are NOT matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
