### PR TITLE
fix(runtime): require explicit marker for agent question detection (#426)

### DIFF
--- a/agent/entrypoint.sh
+++ b/agent/entrypoint.sh
@@ -1014,7 +1014,9 @@ Your mission:
 - If improvements are needed, make the changes directly
 - Commit and push any changes you make
 - Post a comment on the PR summarizing what you did using: gh issue comment ${ISSUE_NUMBER} --body '<your comment>'
-- If you need clarification from the author, post a comment asking for it and stop
+- If you need clarification from the author, post a comment asking for it and stop. The comment MUST start with the literal HTML marker on its own line so the runtime can detect it:
+  <!-- agent-question -->
+  Followed by your question(s). Without this marker the runtime cannot distinguish your question from its own status comments and will silently retry instead of waiting for an answer.
 - Be concise. Make minimal, focused changes.
 
 BEFORE FINISHING:
@@ -1154,7 +1156,7 @@ Your mission:
 - **Before pushing, run the pre-push lint loop** (see Lint Loop Instructions below)
 - Create a PR that references this issue using: gh pr create --title '<title>' --body 'Fixes #${ISSUE_NUMBER}\n\n<description>'
 - If your task does NOT require code changes (e.g., creating issues, analysis, planning), post your results as a comment and close this issue when done using: gh issue close ${ISSUE_NUMBER}
-- If you need more information to proceed, post a comment asking for clarification using: gh issue comment ${ISSUE_NUMBER} --body '<your question>'
+- If you need more information to proceed, post a comment asking for clarification using: gh issue comment ${ISSUE_NUMBER} --body '<your question>'. The comment body MUST start with the literal HTML marker \`<!-- agent-question -->\` on its own line so the runtime can detect it. Without this marker the runtime cannot distinguish your question from its own status comments and will silently retry instead of waiting for an answer.
 - Be concise. Make minimal, focused changes. Don't refactor unrelated code.
 
 ## Lint Loop Instructions

--- a/agent/lib/common.sh
+++ b/agent/lib/common.sh
@@ -156,7 +156,18 @@ find_created_pr_url() {
     '
 }
 
-# Check if there are agent questions in comments
+# Check if there are agent question comments since the run started.
+#
+# A "question comment" is identified by an explicit marker the agent is
+# instructed to include: the literal HTML comment <!-- agent-question -->.
+# This avoids false positives that arose from matching a literal "?" anywhere
+# in the comment body — bot status comments routinely contain artifact URLs
+# like ".../?prefix=tasks/..." which would otherwise short-circuit the
+# retry loop and freeze the issue in agent:waiting with no actual question.
+#
+# A fallback exists for human-authored questions that omit the marker: a
+# comment from a non-bot account that contains "?" *outside of any URL* is
+# also considered a question. URLs are stripped before the fallback check.
 has_agent_question_comment() {
   local issue_number="$1"
   local repo="$2"
@@ -169,7 +180,15 @@ has_agent_question_comment() {
     map(
       select(
         .created_at >= $since
-        and (.body | test("\\?"))
+        and (
+          # Primary: explicit marker from the agent prompt contract.
+          (.body | test("<!-- *agent-question *-->"; "i"))
+          # Fallback: human author with a "?" that is not inside a URL.
+          or (
+            (.user.type // "") != "Bot"
+            and ((.body | gsub("https?://[^\\s)\"]+"; "")) | test("\\?"))
+          )
+        )
       )
     )
     | length > 0

--- a/agent/lib/test_common.sh
+++ b/agent/lib/test_common.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Unit tests for common.sh — run with: bash agent/lib/test_common.sh
+#
+# These tests cover the question-comment detection regression fixed in #426
+# (URL "?" query strings were falsely matched as questions, freezing issues
+# in agent:waiting and short-circuiting the retry loop).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+PASS=0
+FAIL=0
+
+# Override `gh` so tests don't hit the network. Test cases set MOCK_COMMENTS_JSON
+# before calling has_agent_question_comment.
+gh() {
+  if [ "$1" = "api" ]; then
+    printf '%s' "${MOCK_COMMENTS_JSON:-[]}"
+    return 0
+  fi
+  command gh "$@"
+}
+export -f gh
+
+assert_question_detected() {
+  local label="$1"
+  if has_agent_question_comment "1" "fake/repo" "2000-01-01T00:00:00Z" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  ok: ${label}"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: ${label} (expected question detected, got none)"
+  fi
+}
+
+assert_no_question() {
+  local label="$1"
+  if has_agent_question_comment "1" "fake/repo" "2000-01-01T00:00:00Z" 2>/dev/null; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: ${label} (expected no question, but one was detected)"
+  else
+    PASS=$((PASS + 1))
+    echo "  ok: ${label}"
+  fi
+}
+
+# --- Case 1: bot status comment with artifact URL containing ?prefix=... ---
+# This is the regression case from #426. Must NOT be flagged as a question.
+MOCK_COMMENTS_JSON='[
+  {
+    "created_at": "2026-05-06T02:45:54Z",
+    "user": {"type": "Bot", "login": "cenetex[bot]"},
+    "body": "Agent run failed. [View artifacts](https://console.aws.amazon.com/s3/buckets/foo?prefix=tasks/x/y/)"
+  }
+]'
+assert_no_question "bot URL '?prefix=' is not a question"
+
+# --- Case 2: agent comment with the explicit marker ---
+MOCK_COMMENTS_JSON='[
+  {
+    "created_at": "2026-05-06T02:50:00Z",
+    "user": {"type": "Bot", "login": "github-agent[bot]"},
+    "body": "<!-- agent-question -->\nShould I use lib-dynamodb or client-dynamodb?"
+  }
+]'
+assert_question_detected "explicit <!-- agent-question --> marker is detected"
+
+# --- Case 3: human comment with a real question (fallback path) ---
+MOCK_COMMENTS_JSON='[
+  {
+    "created_at": "2026-05-06T03:00:00Z",
+    "user": {"type": "User", "login": "atimics"},
+    "body": "Hey, what bucket should this read from?"
+  }
+]'
+assert_question_detected "human '?' question is detected via fallback"
+
+# --- Case 4: human comment whose only '?' lives in a URL ---
+# Must NOT be flagged — the human said "see this dashboard" with a URL but no question.
+MOCK_COMMENTS_JSON='[
+  {
+    "created_at": "2026-05-06T03:05:00Z",
+    "user": {"type": "User", "login": "atimics"},
+    "body": "see https://example.com/path?x=1 for context"
+  }
+]'
+assert_no_question "human comment with '?' only in URL is not a question"
+
+# --- Case 5: comment older than 'since' is ignored even if it contains a marker ---
+MOCK_COMMENTS_JSON='[
+  {
+    "created_at": "1999-12-31T00:00:00Z",
+    "user": {"type": "Bot", "login": "github-agent[bot]"},
+    "body": "<!-- agent-question -->\nOld question from a prior run"
+  }
+]'
+assert_no_question "marker comment older than since= is ignored"
+
+# --- Case 6: empty comments array ---
+MOCK_COMMENTS_JSON='[]'
+assert_no_question "no comments at all is not a question"
+
+# --- Case 7: bot comment with marker (some flows have the bot relay the agent's question) ---
+MOCK_COMMENTS_JSON='[
+  {
+    "created_at": "2026-05-06T02:50:00Z",
+    "user": {"type": "Bot", "login": "cenetex[bot]"},
+    "body": "Some preamble\n\n<!-- agent-question -->\n\nShould I proceed?"
+  }
+]'
+assert_question_detected "marker anywhere in bot body is detected"
+
+echo
+echo "Passed: ${PASS}, Failed: ${FAIL}"
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
Fixes #426.

## Why

`has_agent_question_comment()` matched any comment whose body contained a `?`. Bot status comments routinely include artifact URLs of the form `.../?prefix=tasks/...`, so the `?` in the URL query string was being read as a question. When that false positive fired, the runtime's retry-loop short-circuited at line 1488 of `entrypoint.sh` — meaning the loop **stopped retrying** after a single silent-success run, freezing the issue in `agent:waiting` with no actual question for the human to answer.

Live evidence: cenetex/agent#422 and cenetex/agent#415, both wedged 2026-05-06 with no agent-authored comments — only bot status comments containing artifact URL `?prefix=`.

## What changed

- **`agent/lib/common.sh`** — `has_agent_question_comment()` now requires an explicit `<!-- agent-question -->` HTML marker as primary detection. Fallback path for human-authored questions: non-bot comment with `?` *outside* any URL is still detected (so reviewers don't need to know about the marker).
- **`agent/entrypoint.sh`** — both prompt branches (PR-review path line 1017 and issue path line 1159) now instruct the agent to lead question comments with the marker, with an explanation of why.
- **`agent/lib/test_common.sh`** (new) — 7 test cases covering: original regression (bot URL '?'), marker happy path, marker anywhere in body, human '?' fallback, URL-only '?' rejection, since-cutoff filter, empty list. All pass locally.

## Verification

\`\`\`
\$ bash agent/lib/test_common.sh
  ok: bot URL '?prefix=' is not a question
  ok: explicit <!-- agent-question --> marker is detected
  ok: human '?' question is detected via fallback
  ok: human comment with '?' only in URL is not a question
  ok: marker comment older than since= is ignored
  ok: no comments at all is not a question
  ok: marker anywhere in bot body is detected

Passed: 7, Failed: 0
\`\`\`

## Once this lands

#422 and #415 (currently wedged in \`agent:waiting\`) should be re-dispatched (re-add the \`agent\` label). The old false-positive path no longer fires, so the retry loop will run cleanly until it either produces a PR or hits MAX_ATTEMPTS.

## Related

- #426 — this bug
- #422 — verify-outputs typecheck gate (wedged by this bug)
- #415 — runner max-tokens cap (wedged by this bug)
- #341 — is_main_also_broken / verify-outputs reliability theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)