### PR TITLE
Harden agent runtime and release controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.20.2
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            infra/package-lock.json
+            agent/package-lock.json
+            website/package-lock.json
+
+      - name: Install root deps
+        run: npm ci
+
+      - name: Validate infra
+        run: |
+          cd infra
+          npm ci
+          npm run build
+          npm test
+
+      - name: Validate agent shell scripts
+        run: |
+          cd agent
+          npm ci
+          npm run build
+          bash -n entrypoint.sh
+          bash -n review-entrypoint.sh
+          bash -n lib/common.sh
+          bash -n lib/orchestrate-lint.sh
+          bash -n lib/lint-loop.sh
+
+      - name: Build website
+        run: |
+          cd website
+          npm ci
+          npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ GitHub Issue
     ↓
   [review:approved] or [review:changes-requested] label
     ↓
-  Auto-merge after 1-hour hold (if approved)
+  Merge after hold period only if a human approval exists
 ```
 
 ### Label Semantics
@@ -77,6 +77,7 @@ The agent uses a trigger + status label system:
 **Review Labels:**
 - `review:approved` - Review agent approved the PR quality
 - `review:changes-requested` - Review agent found issues needing fixes
+- `review:human-required` - Protected files or policy require manual review; auto-merge is blocked
 
 **Status Labels:**
 - `status:blocked` - Indicates task is blocked (credit-aware throttling)
@@ -210,6 +211,15 @@ All scheduled operations use EventBridge rules. Times listed are in UTC:
 | Escalation Checks | Every 15 minutes | Route decisions to human admins |
 | Task Status Monitor | Every 30 minutes | Health checks on running tasks |
 | Credit Rescan | Hourly | Unblock repos when credits available |
+
+## Deployment
+
+GitHub Actions separates validation from deployment:
+
+- `CI` runs on pull requests and pushes to `main`.
+- `Deploy` runs only for published GitHub releases or manual `workflow_dispatch`.
+
+The CDK stack runs agent tasks in private subnets by default. To use the prior lower-cost public-subnet mode for a non-production deployment, pass `-c usePublicSubnets=true` to CDK.
 
 ## Per-Repo Configuration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,13 +23,13 @@ The agent system implements a tiered architecture where different agents have di
 
 **Permissions:**
 - Same as Tier 1 + Opus model (higher capability)
-- Can approve PRs for auto-merge (with 1-hour hold period before merge)
+- Can label PRs as review-approved, but auto-merge also requires a human GitHub review approval and the hold period
 
 **Trigger:** Scheduled (every 15 minutes) or manual label
 
 **Trust Model:** Only reads diffs and posts comments; never trusted with hostile input
 
-**Risk Profile:** Can approve PRs but hold period allows human override before merge
+**Risk Profile:** Can recommend merge, but protected paths and final merge eligibility require human review
 
 ### Tier 3: Diagnostic Agent (label: `diagnose`)
 
@@ -49,10 +49,12 @@ The GitHub Agent executes untrusted code in isolated AWS Fargate tasks within a 
 
 ### Network Isolation
 
-**Public Subnet Execution:**
-- Agent tasks currently run in public subnets with assigned public IPs. This avoids NAT Gateway cost while still blocking inbound access at the security group.
+**Private Subnet Execution:**
+- Agent tasks run in private subnets by default with no public IP assigned.
+- Outbound internet access goes through a NAT gateway.
 - All inbound access is disabled.
 - Outbound access is controlled through explicit security group rules.
+- Public subnet execution remains available only as an explicit cost-saving CDK context override: `-c usePublicSubnets=true`.
 
 **Explicit Egress Controls:**
 - HTTPS (port 443): GitHub API, model inference, and AWS service APIs
@@ -60,7 +62,9 @@ The GitHub Agent executes untrusted code in isolated AWS Fargate tasks within a 
 
 **VPC Endpoints:**
 - S3 Gateway Endpoint: Private access to artifact storage
-- Additional interface endpoints for ECR, CloudWatch Logs, and SSM are not currently provisioned. Those would be needed before moving tasks to private subnets without NAT.
+- ECR API/Docker Interface Endpoints: Private container image access
+- CloudWatch Logs Interface Endpoint: Private task logging
+- SSM Interface Endpoint: Private parameter access
 
 ### Compute Isolation
 
@@ -91,7 +95,7 @@ The GitHub Agent executes untrusted code in isolated AWS Fargate tasks within a 
 
 | Boundary | Control | Purpose |
 |----------|---------|---------|
-| Network | Public subnets with no inbound rules | Avoid direct inbound exposure while preserving outbound access without NAT |
+| Network | Private subnets with NAT | Avoid direct internet exposure for task ENIs |
 | Egress | Security group rules allowing HTTPS only | Limit outbound connections |
 | Compute | Fargate isolation | Prevent task-to-task communication |
 | Storage | Ephemeral containers | No persistent state between tasks |

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -2,23 +2,24 @@ ARG NODE_IMAGE=node:20.20.2-bookworm-slim
 FROM ${NODE_IMAGE}
 
 ARG CLAUDE_CODE_VERSION=2.1.128
+ARG AWS_CLI_VERSION=2.34.46
+ARG GH_CLI_VERSION=2.92.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends git jq curl unzip ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI v2 (needed for S3 artifact uploads)
-RUN curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip \
+RUN curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o /tmp/awscliv2.zip \
   && unzip -q /tmp/awscliv2.zip -d /tmp \
   && /tmp/aws/install \
   && rm -rf /tmp/awscliv2.zip /tmp/aws
 
 # Install gh CLI
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-  && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz \
+  && tar -xzf /tmp/gh.tar.gz -C /tmp \
+  && install -m 0755 "/tmp/gh_${GH_CLI_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh \
+  && rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_CLI_VERSION}_linux_amd64"
 
 # Install Claude Code
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"

--- a/agent/Dockerfile.base
+++ b/agent/Dockerfile.base
@@ -2,23 +2,24 @@ ARG NODE_IMAGE=node:20.20.2-bookworm-slim
 FROM ${NODE_IMAGE}
 
 ARG CLAUDE_CODE_VERSION=2.1.128
+ARG AWS_CLI_VERSION=2.34.46
+ARG GH_CLI_VERSION=2.92.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends git jq curl unzip ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI v2 (needed for S3 artifact uploads)
-RUN curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip \
+RUN curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o /tmp/awscliv2.zip \
   && unzip -q /tmp/awscliv2.zip -d /tmp \
   && /tmp/aws/install \
   && rm -rf /tmp/awscliv2.zip /tmp/aws
 
 # Install gh CLI
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-  && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz \
+  && tar -xzf /tmp/gh.tar.gz -C /tmp \
+  && install -m 0755 "/tmp/gh_${GH_CLI_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh \
+  && rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_CLI_VERSION}_linux_amd64"
 
 # Install Claude Code
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"

--- a/agent/Dockerfile.review
+++ b/agent/Dockerfile.review
@@ -2,23 +2,24 @@ ARG NODE_IMAGE=node:20.20.2-bookworm-slim
 FROM ${NODE_IMAGE}
 
 ARG CLAUDE_CODE_VERSION=2.1.128
+ARG AWS_CLI_VERSION=2.34.46
+ARG GH_CLI_VERSION=2.92.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends git jq curl unzip ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI v2 (needed for S3 artifact uploads)
-RUN curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip \
+RUN curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o /tmp/awscliv2.zip \
   && unzip -q /tmp/awscliv2.zip -d /tmp \
   && /tmp/aws/install \
   && rm -rf /tmp/awscliv2.zip /tmp/aws
 
 # Install gh CLI
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-  && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz \
+  && tar -xzf /tmp/gh.tar.gz -C /tmp \
+  && install -m 0755 "/tmp/gh_${GH_CLI_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh \
+  && rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_CLI_VERSION}_linux_amd64"
 
 # Install Claude Code
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"

--- a/infra/__tests__/agent-config.test.ts
+++ b/infra/__tests__/agent-config.test.ts
@@ -1,0 +1,52 @@
+import {
+  DEFAULT_DISPATCH_CONFIG,
+  DEFAULT_MERGE_HOLD_CONFIG,
+  parseAgentConfig,
+} from '../lib/agent-config';
+
+describe('agent config parsing', () => {
+  it('parses model, dispatch, and merge hold settings', () => {
+    const config = parseAgentConfig(`
+model: anthropic/claude-opus-4-6
+auto_dispatch: false
+auto_dispatch_labels: ready, safe-to-run
+wip_cap: 2
+max_concurrent: 4
+merge_hold_minutes: 90
+merge_hold_minutes_infra: 240
+`);
+
+    expect(config).toEqual({
+      model: 'anthropic/claude-opus-4-6',
+      dispatch: {
+        auto_dispatch: false,
+        auto_dispatch_labels: ['ready', 'safe-to-run'],
+        wip_cap: 2,
+        max_concurrent: 4,
+      },
+      mergeHold: {
+        merge_hold_minutes: 90,
+        merge_hold_minutes_infra: 240,
+      },
+    });
+  });
+
+  it('uses defaults for missing or invalid values', () => {
+    const config = parseAgentConfig(`
+auto_dispatch: maybe
+wip_cap: no
+max_concurrent: -1
+merge_hold_minutes: never
+`);
+
+    expect(config.model).toBeNull();
+    expect(config.dispatch).toEqual(DEFAULT_DISPATCH_CONFIG);
+    expect(config.mergeHold).toEqual(DEFAULT_MERGE_HOLD_CONFIG);
+  });
+
+  it('allows an empty dispatch label list', () => {
+    const config = parseAgentConfig('auto_dispatch_labels:');
+
+    expect(config.dispatch.auto_dispatch_labels).toEqual(DEFAULT_DISPATCH_CONFIG.auto_dispatch_labels);
+  });
+});

--- a/infra/__tests__/fargate-task.test.ts
+++ b/infra/__tests__/fargate-task.test.ts
@@ -1,0 +1,67 @@
+import {
+  createRunTaskInput,
+  parseTaskAssignPublicIp,
+} from '../lib/fargate-task';
+
+describe('fargate task helpers', () => {
+  it('creates a private Fargate run-task request', () => {
+    const input = createRunTaskInput({
+      clusterArn: 'arn:cluster',
+      taskDefinitionArn: 'arn:task-def',
+      containerName: 'agent',
+      subnets: 'subnet-a, subnet-b',
+      securityGroup: 'sg-123',
+      assignPublicIp: 'DISABLED',
+      environment: {
+        FOO: 'bar',
+        BAZ: 'qux',
+      },
+    });
+
+    expect(input).toMatchObject({
+      cluster: 'arn:cluster',
+      taskDefinition: 'arn:task-def',
+      launchType: 'FARGATE',
+      count: 1,
+      networkConfiguration: {
+        awsvpcConfiguration: {
+          subnets: ['subnet-a', 'subnet-b'],
+          securityGroups: ['sg-123'],
+          assignPublicIp: 'DISABLED',
+        },
+      },
+      overrides: {
+        containerOverrides: [
+          {
+            name: 'agent',
+            environment: [
+              { name: 'FOO', value: 'bar' },
+              { name: 'BAZ', value: 'qux' },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('rejects empty subnet configuration', () => {
+    expect(() =>
+      createRunTaskInput({
+        clusterArn: 'arn:cluster',
+        taskDefinitionArn: 'arn:task-def',
+        containerName: 'agent',
+        subnets: ' , ',
+        securityGroup: 'sg-123',
+        assignPublicIp: 'ENABLED',
+        environment: {},
+      })
+    ).toThrow('At least one subnet is required');
+  });
+
+  it('parses public IP mode defensively', () => {
+    expect(parseTaskAssignPublicIp('DISABLED')).toBe('DISABLED');
+    expect(parseTaskAssignPublicIp('disabled')).toBe('DISABLED');
+    expect(parseTaskAssignPublicIp('ENABLED')).toBe('ENABLED');
+    expect(parseTaskAssignPublicIp(undefined)).toBe('ENABLED');
+  });
+});

--- a/infra/__tests__/review-policy.test.ts
+++ b/infra/__tests__/review-policy.test.ts
@@ -1,0 +1,66 @@
+import {
+  hasBlockingAutoMergeLabel,
+  hasCurrentHumanApproval,
+  isHumanApprovalReview,
+} from '../lib/review-policy';
+
+describe('review policy', () => {
+  it('requires a human approved review', () => {
+    expect(isHumanApprovalReview({
+      state: 'APPROVED',
+      user: { login: 'alice', type: 'User' },
+    })).toBe(true);
+
+    expect(isHumanApprovalReview({
+      state: 'CHANGES_REQUESTED',
+      user: { login: 'alice', type: 'User' },
+    })).toBe(false);
+
+    expect(isHumanApprovalReview({
+      state: 'APPROVED',
+      user: { login: 'github-actions[bot]', type: 'Bot' },
+    })).toBe(false);
+  });
+
+  it('blocks auto-merge for pause and human-required labels', () => {
+    expect(hasBlockingAutoMergeLabel(['review:approved'])).toBe(false);
+    expect(hasBlockingAutoMergeLabel(['review:approved', 'pause-agent'])).toBe(true);
+    expect(hasBlockingAutoMergeLabel(['review:approved', 'review:human-required'])).toBe(true);
+  });
+
+  it('uses the latest human review states for merge eligibility', () => {
+    expect(hasCurrentHumanApproval([
+      {
+        state: 'APPROVED',
+        submitted_at: '2026-05-14T00:00:00Z',
+        user: { login: 'alice', type: 'User' },
+      },
+    ])).toBe(true);
+
+    expect(hasCurrentHumanApproval([
+      {
+        state: 'APPROVED',
+        submitted_at: '2026-05-14T00:00:00Z',
+        user: { login: 'alice', type: 'User' },
+      },
+      {
+        state: 'CHANGES_REQUESTED',
+        submitted_at: '2026-05-14T01:00:00Z',
+        user: { login: 'alice', type: 'User' },
+      },
+    ])).toBe(false);
+
+    expect(hasCurrentHumanApproval([
+      {
+        state: 'APPROVED',
+        submitted_at: '2026-05-14T00:00:00Z',
+        user: { login: 'alice', type: 'User' },
+      },
+      {
+        state: 'CHANGES_REQUESTED',
+        submitted_at: '2026-05-14T01:00:00Z',
+        user: { login: 'bob', type: 'User' },
+      },
+    ])).toBe(false);
+  });
+});

--- a/infra/lib/agent-config.ts
+++ b/infra/lib/agent-config.ts
@@ -1,0 +1,93 @@
+export interface DispatchConfig {
+  auto_dispatch: boolean;
+  auto_dispatch_labels: string[];
+  wip_cap: number;
+  max_concurrent: number;
+}
+
+export interface MergeHoldConfig {
+  merge_hold_minutes: number;
+  merge_hold_minutes_infra: number;
+}
+
+export interface AgentConfig {
+  model: string | null;
+  dispatch: DispatchConfig;
+  mergeHold: MergeHoldConfig;
+}
+
+export const DEFAULT_DISPATCH_CONFIG: DispatchConfig = {
+  auto_dispatch: true,
+  auto_dispatch_labels: ["ready"],
+  wip_cap: 0,
+  max_concurrent: 3,
+};
+
+export const DEFAULT_MERGE_HOLD_CONFIG: MergeHoldConfig = {
+  merge_hold_minutes: 60,
+  merge_hold_minutes_infra: 120,
+};
+
+function getConfigValue(content: string, key: string): string | null {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = content.match(new RegExp(`^${escapedKey}:\\s*(.+)$`, "m"));
+  return match?.[1]?.trim() ?? null;
+}
+
+function parseBoolean(value: string | null, fallback: boolean): boolean {
+  if (value === null) return fallback;
+  const normalized = value.toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  return fallback;
+}
+
+function parseNonNegativeInteger(value: string | null, fallback: number): number {
+  if (value === null) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function parseLabelList(value: string | null, fallback: string[]): string[] {
+  if (value === null) return fallback;
+  return value
+    .split(",")
+    .map((label) => label.trim())
+    .filter(Boolean);
+}
+
+export function parseAgentConfig(content: string): AgentConfig {
+  const model = getConfigValue(content, "model");
+
+  return {
+    model,
+    dispatch: {
+      auto_dispatch: parseBoolean(
+        getConfigValue(content, "auto_dispatch"),
+        DEFAULT_DISPATCH_CONFIG.auto_dispatch
+      ),
+      auto_dispatch_labels: parseLabelList(
+        getConfigValue(content, "auto_dispatch_labels"),
+        DEFAULT_DISPATCH_CONFIG.auto_dispatch_labels
+      ),
+      wip_cap: parseNonNegativeInteger(
+        getConfigValue(content, "wip_cap"),
+        DEFAULT_DISPATCH_CONFIG.wip_cap
+      ),
+      max_concurrent: parseNonNegativeInteger(
+        getConfigValue(content, "max_concurrent"),
+        DEFAULT_DISPATCH_CONFIG.max_concurrent
+      ),
+    },
+    mergeHold: {
+      merge_hold_minutes: parseNonNegativeInteger(
+        getConfigValue(content, "merge_hold_minutes"),
+        DEFAULT_MERGE_HOLD_CONFIG.merge_hold_minutes
+      ),
+      merge_hold_minutes_infra: parseNonNegativeInteger(
+        getConfigValue(content, "merge_hold_minutes_infra"),
+        DEFAULT_MERGE_HOLD_CONFIG.merge_hold_minutes_infra
+      ),
+    },
+  };
+}

--- a/infra/lib/fargate-task.ts
+++ b/infra/lib/fargate-task.ts
@@ -1,0 +1,58 @@
+import type { RunTaskCommandInput } from "@aws-sdk/client-ecs";
+
+export type TaskAssignPublicIp = "ENABLED" | "DISABLED";
+
+export interface CreateRunTaskInputOptions {
+  clusterArn: string;
+  taskDefinitionArn: string;
+  containerName: string;
+  subnets: string;
+  securityGroup: string;
+  environment: Record<string, string | undefined>;
+  assignPublicIp: TaskAssignPublicIp;
+}
+
+export function parseTaskAssignPublicIp(value: string | undefined): TaskAssignPublicIp {
+  if (value?.toUpperCase() === "DISABLED") {
+    return "DISABLED";
+  }
+  return "ENABLED";
+}
+
+export function createRunTaskInput(options: CreateRunTaskInputOptions): RunTaskCommandInput {
+  const subnets = options.subnets
+    .split(",")
+    .map((subnet) => subnet.trim())
+    .filter(Boolean);
+
+  if (subnets.length === 0) {
+    throw new Error("At least one subnet is required to launch a Fargate task");
+  }
+
+  return {
+    cluster: options.clusterArn,
+    taskDefinition: options.taskDefinitionArn,
+    launchType: "FARGATE",
+    count: 1,
+    networkConfiguration: {
+      awsvpcConfiguration: {
+        subnets,
+        securityGroups: [options.securityGroup],
+        assignPublicIp: options.assignPublicIp,
+      },
+    },
+    overrides: {
+      containerOverrides: [
+        {
+          name: options.containerName,
+          environment: Object.entries(options.environment)
+            .filter((entry): entry is [string, string] => entry[1] !== undefined)
+            .map(([name, value]) => ({
+              name,
+              value,
+            })),
+        },
+      ],
+    },
+  };
+}

--- a/infra/lib/review-handler.ts
+++ b/infra/lib/review-handler.ts
@@ -1,7 +1,6 @@
 import {
   ECSClient,
   RunTaskCommand,
-  type RunTaskCommandInput,
 } from "@aws-sdk/client-ecs";
 import {
   SSMClient,
@@ -23,6 +22,14 @@ import {
   type ReviewEnvironment,
   type GitHubAppConfig,
 } from "./types";
+import {
+  createRunTaskInput,
+  parseTaskAssignPublicIp,
+} from "./fargate-task";
+import {
+  hasCurrentHumanApproval,
+  hasBlockingAutoMergeLabel,
+} from "./review-policy";
 
 const ecs = new ECSClient({});
 const ssm = new SSMClient({});
@@ -33,6 +40,7 @@ const REVIEW_TASK_DEFINITION_ARN = process.env.REVIEW_TASK_DEFINITION_ARN!;
 const REVIEW_CONTAINER_NAME = process.env.REVIEW_CONTAINER_NAME!;
 const SUBNETS = process.env.SUBNETS!;
 const SECURITY_GROUP = process.env.SECURITY_GROUP!;
+const TASK_ASSIGN_PUBLIC_IP = parseTaskAssignPublicIp(process.env.TASK_ASSIGN_PUBLIC_IP);
 const GITHUB_APP_ID_PARAM = process.env.GITHUB_APP_ID_PARAM!;
 const GITHUB_APP_PRIVATE_KEY_PARAM = process.env.GITHUB_APP_PRIVATE_KEY_PARAM!;
 const OPENROUTER_API_KEY_PARAM = process.env.OPENROUTER_API_KEY_PARAM!;
@@ -346,30 +354,15 @@ async function startReviewTask(
     REVIEW_CRITERIA: JSON.stringify(reviewCriteria),
   };
 
-  const params: RunTaskCommandInput = {
-    cluster: CLUSTER_ARN,
-    taskDefinition: REVIEW_TASK_DEFINITION_ARN,
-    launchType: "FARGATE",
-    count: 1,
-    networkConfiguration: {
-      awsvpcConfiguration: {
-        subnets: SUBNETS.split(","),
-        securityGroups: [SECURITY_GROUP],
-        assignPublicIp: "ENABLED",
-      },
-    },
-    overrides: {
-      containerOverrides: [
-        {
-          name: REVIEW_CONTAINER_NAME,
-          environment: Object.entries(reviewEnvironment).map(([name, value]) => ({
-            name,
-            value,
-          })),
-        },
-      ],
-    },
-  };
+  const params = createRunTaskInput({
+    clusterArn: CLUSTER_ARN,
+    taskDefinitionArn: REVIEW_TASK_DEFINITION_ARN,
+    containerName: REVIEW_CONTAINER_NAME,
+    subnets: SUBNETS,
+    securityGroup: SECURITY_GROUP,
+    environment: { ...reviewEnvironment },
+    assignPublicIp: TASK_ASSIGN_PUBLIC_IP,
+  });
 
   const result = await ecs.send(new RunTaskCommand(params));
   const taskArn = result.tasks?.[0]?.taskArn;
@@ -456,19 +449,30 @@ async function mergeApprovedPRs(token: string): Promise<void> {
 
       // Filter PRs with review:approved label
       const approvedPRs = prs.filter((pr: any) => {
+        const labels = pr.labels.map((label: any) => label.name);
         const hasApprovedLabel = pr.labels.some((label: any) =>
           label.name === "review:approved"
         );
 
-        const hasPauseLabel = pr.labels.some((label: any) =>
-          label.name === "pause-agent"
-        );
-
-        return hasApprovedLabel && !hasPauseLabel;
+        return hasApprovedLabel && !hasBlockingAutoMergeLabel(labels);
       });
 
       for (const pr of approvedPRs) {
         try {
+          const reviewsResponse = await githubRequest(
+            `/repos/${repo}/pulls/${pr.number}/reviews?per_page=100`,
+            token,
+            { method: "GET" },
+            [200]
+          );
+          const reviews = await reviewsResponse.json() as any[];
+          const hasHumanApproval = hasCurrentHumanApproval(reviews);
+
+          if (!hasHumanApproval) {
+            console.log(`PR ${pr.number}: review:approved label exists but no human approving review was found, skipping auto-merge`);
+            continue;
+          }
+
           // Get the label events to check when review:approved was added
           const labelsResponse = await githubRequest(
             `/repos/${repo}/issues/${pr.number}/events`,

--- a/infra/lib/review-policy.ts
+++ b/infra/lib/review-policy.ts
@@ -1,0 +1,55 @@
+export interface GitHubReviewSummary {
+  state?: string;
+  submitted_at?: string;
+  user?: {
+    login?: string;
+    type?: string;
+  } | null;
+}
+
+const AUTO_MERGE_BLOCKING_LABELS = new Set([
+  "pause-agent",
+  "review:human-required",
+]);
+
+export function hasBlockingAutoMergeLabel(labels: string[]): boolean {
+  return labels.some((label) => AUTO_MERGE_BLOCKING_LABELS.has(label));
+}
+
+export function isHumanApprovalReview(review: GitHubReviewSummary): boolean {
+  return isHumanReview(review) && review.state === "APPROVED";
+}
+
+function isHumanReview(review: GitHubReviewSummary): boolean {
+  const login = review.user?.login ?? "";
+  const type = review.user?.type ?? "";
+
+  if (!login) {
+    return false;
+  }
+
+  if (type === "Bot" || login.endsWith("[bot]")) {
+    return false;
+  }
+
+  return true;
+}
+
+export function hasCurrentHumanApproval(reviews: GitHubReviewSummary[]): boolean {
+  const latestByReviewer = new Map<string, GitHubReviewSummary>();
+  const sortedReviews = [...reviews].sort((a, b) => {
+    const aTime = a.submitted_at ? new Date(a.submitted_at).getTime() : 0;
+    const bTime = b.submitted_at ? new Date(b.submitted_at).getTime() : 0;
+    return aTime - bTime;
+  });
+
+  for (const review of sortedReviews) {
+    if (!isHumanReview(review)) {
+      continue;
+    }
+    latestByReviewer.set(review.user!.login!, review);
+  }
+
+  const latestStates = [...latestByReviewer.values()].map((review) => review.state);
+  return latestStates.includes("APPROVED") && !latestStates.includes("CHANGES_REQUESTED");
+}

--- a/infra/lib/stack.ts
+++ b/infra/lib/stack.ts
@@ -42,20 +42,38 @@ export class GitHubAgentStack extends cdk.Stack {
         `arn:aws:ssm:${this.region}:${this.account}:parameter${name}`
     );
 
+    const usePublicSubnets = this.node.tryGetContext("usePublicSubnets") === "true";
+    const agentSubnetType = usePublicSubnets
+      ? ec2.SubnetType.PUBLIC
+      : ec2.SubnetType.PRIVATE_WITH_EGRESS;
+    const taskAssignPublicIp = usePublicSubnets ? "ENABLED" : "DISABLED";
+
     // -------------------------------------------------------
-    // VPC — public subnets for cost efficiency
+    // VPC — private task subnets by default
     // -------------------------------------------------------
     const vpc = new ec2.Vpc(this, "AgentVpc", {
       maxAzs: 2,
-      natGateways: 0, // No NAT gateway — use public subnets instead
+      natGateways: usePublicSubnets ? 0 : 1,
       subnetConfiguration: [
         {
           name: "Public",
           subnetType: ec2.SubnetType.PUBLIC,
           cidrMask: 24,
         },
+        ...(usePublicSubnets
+          ? []
+          : [
+              {
+                name: "Private",
+                subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                cidrMask: 24,
+              },
+            ]),
       ],
     });
+
+    const agentSubnets = usePublicSubnets ? vpc.publicSubnets : vpc.privateSubnets;
+    const agentSubnetIds = agentSubnets.map((s) => s.subnetId).join(",");
 
     const taskSecurityGroup = new ec2.SecurityGroup(this, "TaskSG", {
       vpc,
@@ -77,9 +95,28 @@ export class GitHubAgentStack extends cdk.Stack {
     vpc.addGatewayEndpoint("S3GatewayEndpoint", {
       service: ec2.GatewayVpcEndpointAwsService.S3,
       subnets: [
-        { subnetType: ec2.SubnetType.PUBLIC },
+        { subnetType: agentSubnetType },
       ],
     });
+
+    if (!usePublicSubnets) {
+      vpc.addInterfaceEndpoint("EcrApiEndpoint", {
+        service: ec2.InterfaceVpcEndpointAwsService.ECR,
+        subnets: { subnetType: agentSubnetType },
+      });
+      vpc.addInterfaceEndpoint("EcrDockerEndpoint", {
+        service: ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER,
+        subnets: { subnetType: agentSubnetType },
+      });
+      vpc.addInterfaceEndpoint("CloudWatchLogsEndpoint", {
+        service: ec2.InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS,
+        subnets: { subnetType: agentSubnetType },
+      });
+      vpc.addInterfaceEndpoint("SsmEndpoint", {
+        service: ec2.InterfaceVpcEndpointAwsService.SSM,
+        subnets: { subnetType: agentSubnetType },
+      });
+    }
 
     // -------------------------------------------------------
     // S3 Bucket for Task Artifacts
@@ -278,8 +315,9 @@ export class GitHubAgentStack extends cdk.Stack {
         CONTAINER_NAME: containerName,
         DIAGNOSTIC_CONTAINER_NAME: diagnosticContainerName,
         REVIEW_CONTAINER_NAME: reviewContainerName,
-        SUBNETS: vpc.publicSubnets.map((s) => s.subnetId).join(","),
+        SUBNETS: agentSubnetIds,
         SECURITY_GROUP: taskSecurityGroup.securityGroupId,
+        TASK_ASSIGN_PUBLIC_IP: taskAssignPublicIp,
         WEBHOOK_SECRET_PARAM: PARAM_WEBHOOK_SECRET,
         GITHUB_APP_ID_PARAM: PARAM_GITHUB_APP_ID,
         GITHUB_APP_PRIVATE_KEY_PARAM: PARAM_GITHUB_APP_PRIVATE_KEY,
@@ -343,8 +381,9 @@ export class GitHubAgentStack extends cdk.Stack {
         CLUSTER_ARN: cluster.clusterArn,
         REVIEW_TASK_DEFINITION_ARN: reviewTaskDefinition.taskDefinitionArn,
         REVIEW_CONTAINER_NAME: reviewContainerName,
-        SUBNETS: vpc.publicSubnets.map((s) => s.subnetId).join(","),
+        SUBNETS: agentSubnetIds,
         SECURITY_GROUP: taskSecurityGroup.securityGroupId,
+        TASK_ASSIGN_PUBLIC_IP: taskAssignPublicIp,
         GITHUB_APP_ID_PARAM: PARAM_GITHUB_APP_ID,
         GITHUB_APP_PRIVATE_KEY_PARAM: PARAM_GITHUB_APP_PRIVATE_KEY,
         OPENROUTER_API_KEY_PARAM: PARAM_OPENROUTER_KEY,
@@ -892,6 +931,11 @@ export class GitHubAgentStack extends cdk.Stack {
     new cdk.CfnOutput(this, "ArtifactsBucket", {
       value: artifactsBucket.bucketName,
       description: "S3 bucket for task artifacts and metadata",
+    });
+
+    new cdk.CfnOutput(this, "TaskNetworkMode", {
+      value: usePublicSubnets ? "public-subnets-public-ip" : "private-subnets-nat",
+      description: "Network mode used for agent Fargate tasks",
     });
   }
 }

--- a/infra/lib/webhook-handler.ts
+++ b/infra/lib/webhook-handler.ts
@@ -2,7 +2,6 @@ import { createHmac } from "crypto";
 import {
   ECSClient,
   RunTaskCommand,
-  type RunTaskCommandInput,
 } from "@aws-sdk/client-ecs";
 import {
   SSMClient,
@@ -41,6 +40,16 @@ import {
   PROTECTED_PATHS,
   CODING_AGENT_BOT_LOGINS,
 } from "./types";
+import {
+  DEFAULT_DISPATCH_CONFIG,
+  DEFAULT_MERGE_HOLD_CONFIG,
+  parseAgentConfig,
+  type DispatchConfig,
+} from "./agent-config";
+import {
+  createRunTaskInput,
+  parseTaskAssignPublicIp,
+} from "./fargate-task";
 import { publishDigestToSocialMedia } from "./digest-publisher";
 
 const ecs = new ECSClient({});
@@ -54,6 +63,7 @@ const CONTAINER_NAME = process.env.CONTAINER_NAME!;
 const DIAGNOSTIC_CONTAINER_NAME = process.env.DIAGNOSTIC_CONTAINER_NAME!;
 const SUBNETS = process.env.SUBNETS!;
 const SECURITY_GROUP = process.env.SECURITY_GROUP!;
+const TASK_ASSIGN_PUBLIC_IP = parseTaskAssignPublicIp(process.env.TASK_ASSIGN_PUBLIC_IP);
 const WEBHOOK_SECRET_PARAM = process.env.WEBHOOK_SECRET_PARAM!;
 const GITHUB_APP_ID_PARAM = process.env.GITHUB_APP_ID_PARAM!;
 const GITHUB_APP_PRIVATE_KEY_PARAM = process.env.GITHUB_APP_PRIVATE_KEY_PARAM!;
@@ -231,7 +241,7 @@ async function getIssueLabels(
   return issueData.labels.map((label: any) => label.name);
 }
 
-async function getRepoModelConfig(
+async function getRepoAgentConfigContent(
   repoOwner: string,
   repoName: string,
   token: string
@@ -253,16 +263,20 @@ async function getRepoModelConfig(
       return null;
     }
 
-    // Decode base64 content
-    const decoded = Buffer.from(content.content, "base64").toString("utf8");
-
-    // Simple regex to extract model line: "model: anthropic/claude-sonnet-4"
-    const modelMatch = decoded.match(/^model:\s*(.+)$/m);
-    return modelMatch ? modelMatch[1].trim() : null;
+    return Buffer.from(content.content, "base64").toString("utf8");
   } catch (error) {
     console.log(`Failed to fetch .github/AGENT.md: ${error}`);
     return null;
   }
+}
+
+async function getRepoModelConfig(
+  repoOwner: string,
+  repoName: string,
+  token: string
+): Promise<string | null> {
+  const content = await getRepoAgentConfigContent(repoOwner, repoName, token);
+  return content ? parseAgentConfig(content).model : null;
 }
 
 function getDefaultModel(taskMode: "issue" | "pull_request" | "planning"): string {
@@ -608,30 +622,15 @@ async function triggerReviewForPR(
     const REVIEW_TASK_DEFINITION_ARN = process.env.REVIEW_TASK_DEFINITION_ARN!;
     const REVIEW_CONTAINER_NAME = process.env.REVIEW_CONTAINER_NAME!;
 
-    const params: RunTaskCommandInput = {
-      cluster: CLUSTER_ARN,
-      taskDefinition: REVIEW_TASK_DEFINITION_ARN,
-      launchType: "FARGATE",
-      count: 1,
-      networkConfiguration: {
-        awsvpcConfiguration: {
-          subnets: SUBNETS.split(","),
-          securityGroups: [SECURITY_GROUP],
-          assignPublicIp: "ENABLED",
-        },
-      },
-      overrides: {
-        containerOverrides: [
-          {
-            name: REVIEW_CONTAINER_NAME,
-            environment: Object.entries(reviewEnvironment).map(([name, value]) => ({
-              name,
-              value,
-            })),
-          },
-        ],
-      },
-    };
+    const params = createRunTaskInput({
+      clusterArn: CLUSTER_ARN,
+      taskDefinitionArn: REVIEW_TASK_DEFINITION_ARN,
+      containerName: REVIEW_CONTAINER_NAME,
+      subnets: SUBNETS,
+      securityGroup: SECURITY_GROUP,
+      environment: reviewEnvironment,
+      assignPublicIp: TASK_ASSIGN_PUBLIC_IP,
+    });
 
     const result = await ecs.send(new RunTaskCommand(params));
     const taskArn = result.tasks?.[0]?.taskArn;
@@ -1169,24 +1168,6 @@ function detectCircularDependency(
 }
 
 /**
- * Configuration for issue dispatch (read from .github/AGENT.md)
- */
-interface DispatchConfig {
-  auto_dispatch: boolean;
-  auto_dispatch_labels: string[];
-  wip_cap: number;
-  max_concurrent: number;
-}
-
-/**
- * Configuration for merge hold period (read from .github/AGENT.md)
- */
-interface MergeHoldConfig {
-  merge_hold_minutes: number;
-  merge_hold_minutes_infra: number;
-}
-
-/**
  * Reads dispatch configuration from repo's .github/AGENT.md
  * Returns config with defaults if file doesn't exist
  */
@@ -1195,44 +1176,8 @@ async function getDispatchConfig(
   repoName: string,
   token: string
 ): Promise<DispatchConfig> {
-  try {
-    const response = await githubRequest(
-      `/repos/${repoOwner}/${repoName}/contents/.github/AGENT.md`,
-      token,
-      { method: "GET" },
-      [200, 404]
-    );
-
-    if (response.status === 404) {
-      return { auto_dispatch: true, auto_dispatch_labels: ["ready"], wip_cap: 0, max_concurrent: 3 };
-    }
-
-    const content = await response.json() as any;
-    if (content.type !== "file" || !content.content) {
-      return { auto_dispatch: true, auto_dispatch_labels: ["ready"], wip_cap: 0, max_concurrent: 3 };
-    }
-
-    // Decode base64 content
-    const decoded = Buffer.from(content.content as string, "base64").toString("utf8");
-
-    // Extract configuration lines
-    const autoDispatchMatch = decoded.match(/^auto_dispatch:\s*(.+)$/m);
-    const labelsMatch = decoded.match(/^auto_dispatch_labels:\s*(.+)$/m);
-    const wipCapMatch = decoded.match(/^wip_cap:\s*(\d+)$/m);
-    const maxConcurrentMatch = decoded.match(/^max_concurrent:\s*(\d+)$/m);
-
-    const auto_dispatch = autoDispatchMatch ? autoDispatchMatch[1].trim().toLowerCase() === "true" : true;
-    const auto_dispatch_labels = labelsMatch
-      ? labelsMatch[1].trim().split(",").map(l => l.trim()).filter(l => l)
-      : ["ready"];
-    const wip_cap = wipCapMatch ? parseInt(wipCapMatch[1], 10) : 0;
-    const max_concurrent = maxConcurrentMatch ? parseInt(maxConcurrentMatch[1], 10) : 3;
-
-    return { auto_dispatch, auto_dispatch_labels, wip_cap, max_concurrent };
-  } catch (error) {
-    console.log(`Failed to fetch dispatch config from .github/AGENT.md: ${error}`);
-    return { auto_dispatch: true, auto_dispatch_labels: ["ready"], wip_cap: 0, max_concurrent: 3 };
-  }
+  const content = await getRepoAgentConfigContent(repoOwner, repoName, token);
+  return content ? parseAgentConfig(content).dispatch : DEFAULT_DISPATCH_CONFIG;
 }
 
 /**
@@ -1264,33 +1209,12 @@ async function getMergeHoldConfig(
       return 5;
     }
 
-    // Get .github/AGENT.md config
-    const configResponse = await githubRequest(
-      `/repos/${repoOwner}/${repoName}/contents/.github/AGENT.md`,
-      token,
-      { method: "GET" },
-      [200, 404]
-    );
-
-    let mergeHoldMinutes = 60; // default
-    let mergeHoldMinutesInfra = 120; // default for infra paths
-
-    if (configResponse.status === 200) {
-      const content = await configResponse.json() as any;
-      if (content.type === "file" && content.content) {
-        const decoded = Buffer.from(content.content as string, "base64").toString("utf8");
-
-        const holdMatch = decoded.match(/^merge_hold_minutes:\s*(\d+)$/m);
-        if (holdMatch) {
-          mergeHoldMinutes = parseInt(holdMatch[1], 10);
-        }
-
-        const holdInfraMatch = decoded.match(/^merge_hold_minutes_infra:\s*(\d+)$/m);
-        if (holdInfraMatch) {
-          mergeHoldMinutesInfra = parseInt(holdInfraMatch[1], 10);
-        }
-      }
-    }
+    const content = await getRepoAgentConfigContent(repoOwner, repoName, token);
+    const mergeHoldConfig = content
+      ? parseAgentConfig(content).mergeHold
+      : DEFAULT_MERGE_HOLD_CONFIG;
+    const mergeHoldMinutes = mergeHoldConfig.merge_hold_minutes;
+    const mergeHoldMinutesInfra = mergeHoldConfig.merge_hold_minutes_infra;
 
     // Check if PR touches infra/ paths
     const filesResponse = await githubRequest(
@@ -1311,8 +1235,8 @@ async function getMergeHoldConfig(
     console.log(`PR #${prNumber} using default ${mergeHoldMinutes} minute hold period`);
     return mergeHoldMinutes;
   } catch (error) {
-    console.log(`Failed to fetch merge hold config, using default 60 minutes: ${error}`);
-    return 60;
+    console.log(`Failed to fetch merge hold config, using default ${DEFAULT_MERGE_HOLD_CONFIG.merge_hold_minutes} minutes: ${error}`);
+    return DEFAULT_MERGE_HOLD_CONFIG.merge_hold_minutes;
   }
 }
 
@@ -2651,30 +2575,15 @@ function createTaskEnvironmentForDiagnostic(
 async function launchDiagnosticFargateTask(
   taskEnvironment: Record<string, string>
 ): Promise<void> {
-  const params: RunTaskCommandInput = {
-    cluster: CLUSTER_ARN,
-    taskDefinition: DIAGNOSTIC_TASK_DEFINITION_ARN,
-    launchType: "FARGATE",
-    count: 1,
-    networkConfiguration: {
-      awsvpcConfiguration: {
-        subnets: SUBNETS.split(","),
-        securityGroups: [SECURITY_GROUP],
-        assignPublicIp: "ENABLED",
-      },
-    },
-    overrides: {
-      containerOverrides: [
-        {
-          name: DIAGNOSTIC_CONTAINER_NAME,
-          environment: Object.entries(taskEnvironment).map(([name, value]) => ({
-            name,
-            value,
-          })),
-        },
-      ],
-    },
-  };
+  const params = createRunTaskInput({
+    clusterArn: CLUSTER_ARN,
+    taskDefinitionArn: DIAGNOSTIC_TASK_DEFINITION_ARN,
+    containerName: DIAGNOSTIC_CONTAINER_NAME,
+    subnets: SUBNETS,
+    securityGroup: SECURITY_GROUP,
+    environment: taskEnvironment,
+    assignPublicIp: TASK_ASSIGN_PUBLIC_IP,
+  });
 
   const result = await ecs.send(new RunTaskCommand(params));
   const taskArn = result.tasks?.[0]?.taskArn;
@@ -4397,30 +4306,15 @@ Add the \`agent\` label again after purchasing credits. Credits can be purchased
       SIGNAL_LABEL_SUCCEEDED,
     };
 
-    const params: RunTaskCommandInput = {
-      cluster: CLUSTER_ARN,
-      taskDefinition: TASK_DEFINITION_ARN,
-      launchType: "FARGATE",
-      count: 1,
-      networkConfiguration: {
-        awsvpcConfiguration: {
-          subnets: SUBNETS.split(","),
-          securityGroups: [SECURITY_GROUP],
-          assignPublicIp: "ENABLED",
-        },
-      },
-      overrides: {
-        containerOverrides: [
-          {
-            name: CONTAINER_NAME,
-            environment: Object.entries(taskEnvironment).map(([name, value]) => ({
-              name,
-              value,
-            })),
-          },
-        ],
-      },
-    };
+    const params = createRunTaskInput({
+      clusterArn: CLUSTER_ARN,
+      taskDefinitionArn: TASK_DEFINITION_ARN,
+      containerName: CONTAINER_NAME,
+      subnets: SUBNETS,
+      securityGroup: SECURITY_GROUP,
+      environment: { ...taskEnvironment },
+      assignPublicIp: TASK_ASSIGN_PUBLIC_IP,
+    });
 
     const result = await ecs.send(new RunTaskCommand(params));
     const taskArn = result.tasks?.[0]?.taskArn;

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -8,31 +8,35 @@
       "name": "github-agent-infra",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.82.0",
+        "@anthropic-ai/sdk": "^0.96.0",
         "@aws-sdk/client-cloudwatch": "^3.1010.0",
         "@aws-sdk/client-ecs": "^3.1010.0",
         "@aws-sdk/client-s3": "^3.1014.0",
         "@aws-sdk/client-ssm": "^3.1010.0",
-        "aws-cdk-lib": "^2.170.0",
-        "constructs": "^10.4.2"
+        "aws-cdk-lib": "^2.254.0",
+        "constructs": "^10.5.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "@types/node": "^22.0.0",
-        "aws-cdk": "^2.170.0",
-        "esbuild": "^0.24.0",
+        "@types/source-map-support": "^0.5.10",
+        "aws-cdk": "^2.1121.0",
+        "esbuild": "^0.28.0",
         "jest": "^29.7.0",
+        "source-map-support": "^0.5.21",
         "ts-jest": "^29.1.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.7.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
-      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.96.0.tgz",
+      "integrity": "sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -47,9 +51,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.263",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
-      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -59,9 +63,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-      "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
+      "version": "53.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.23.0.tgz",
+      "integrity": "sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -69,7 +73,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -84,7 +88,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1607,10 +1611,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -1625,9 +1653,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -1642,9 +1670,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -1659,9 +1687,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -1676,9 +1704,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -1693,9 +1721,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -1710,9 +1738,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1727,9 +1755,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -1744,9 +1772,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -1761,9 +1789,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -1778,9 +1806,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -1795,9 +1823,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -1812,9 +1840,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -1829,9 +1857,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -1846,9 +1874,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1863,9 +1891,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -1880,9 +1908,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -1897,9 +1925,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -1914,9 +1942,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -1931,9 +1959,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -1948,9 +1976,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -1964,10 +1992,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -1982,9 +2027,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -1999,9 +2044,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -2016,9 +2061,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -3180,6 +3225,40 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3283,6 +3362,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/source-map-support": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-tgVP2H469x9zq34Z0m/fgPewGhg/MLClalNOiPIzQlXrSS2YrKu/xCdSCKnEDwkFha51VKEKB6A9wW26/ZNwzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -3306,6 +3395,32 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -3363,6 +3478,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3374,9 +3496,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1111.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1111.0.tgz",
-      "integrity": "sha512-69AVF04cxbAhYzmeJYtUF5bs6ruNnH05EQZJfjadk5Lpg+HVaJY2NjG/2qgsMmKrfRgvLet73Ir8ehVlAaaGng==",
+      "version": "2.1121.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1121.0.tgz",
+      "integrity": "sha512-cG7CHt/SytYTfwrK+BUNQpqmS1dwhjt8z6ExKL6GK4n+8/6ZCwFzxlZWA/jUd2+Y9xPc+Q8cLKfMqGmgxEXbkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3387,9 +3509,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.243.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.243.0.tgz",
-      "integrity": "sha512-qIhg/3gSNeZ9LoVmDATO45HPk+POkoCfPZRezeOPhd2kAJ/wzYswyUcMqpDWXrlRrEVYntxsykQs+2eMA04Isg==",
+      "version": "2.254.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
+      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -3406,10 +3528,10 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.263",
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.1.1",
-        "@aws-cdk/cloud-assembly-schema": "^52.1.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.3",
+        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -3420,7 +3542,7 @@
         "punycode": "^2.3.1",
         "semver": "^7.7.4",
         "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "yaml": "1.10.3"
       },
       "engines": {
         "node": ">= 20.0.0"
@@ -3430,41 +3552,28 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.1.1",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -3526,7 +3635,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3571,7 +3680,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -3668,11 +3777,11 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3772,7 +3881,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4161,9 +4270,9 @@
       "license": "MIT"
     },
     "node_modules/constructs": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
-      "integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.0.tgz",
+      "integrity": "sha512-zWjwqIgk4nAWmQGrPnDWv+M2Yly6m7ROyqmmQVLgJiHnWP762It22uWFaF2Pu/sSx0u8WsoUcvt0PZ4DQIQYwQ==",
       "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {
@@ -4194,6 +4303,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4263,6 +4379,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -4311,9 +4437,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4324,31 +4450,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.2",
-        "@esbuild/android-arm": "0.24.2",
-        "@esbuild/android-arm64": "0.24.2",
-        "@esbuild/android-x64": "0.24.2",
-        "@esbuild/darwin-arm64": "0.24.2",
-        "@esbuild/darwin-x64": "0.24.2",
-        "@esbuild/freebsd-arm64": "0.24.2",
-        "@esbuild/freebsd-x64": "0.24.2",
-        "@esbuild/linux-arm": "0.24.2",
-        "@esbuild/linux-arm64": "0.24.2",
-        "@esbuild/linux-ia32": "0.24.2",
-        "@esbuild/linux-loong64": "0.24.2",
-        "@esbuild/linux-mips64el": "0.24.2",
-        "@esbuild/linux-ppc64": "0.24.2",
-        "@esbuild/linux-riscv64": "0.24.2",
-        "@esbuild/linux-s390x": "0.24.2",
-        "@esbuild/linux-x64": "0.24.2",
-        "@esbuild/netbsd-arm64": "0.24.2",
-        "@esbuild/netbsd-x64": "0.24.2",
-        "@esbuild/openbsd-arm64": "0.24.2",
-        "@esbuild/openbsd-x64": "0.24.2",
-        "@esbuild/sunos-x64": "0.24.2",
-        "@esbuild/win32-arm64": "0.24.2",
-        "@esbuild/win32-ia32": "0.24.2",
-        "@esbuild/win32-x64": "0.24.2"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -4442,10 +4569,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -4454,7 +4587,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -5307,6 +5441,17 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/jest-runtime": {
@@ -6164,9 +6309,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6192,6 +6337,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/string-length": {
@@ -6427,6 +6582,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6522,6 +6721,13 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -6609,6 +6815,21 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6653,6 +6874,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/infra/package.json
+++ b/infra/package.json
@@ -12,21 +12,24 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.82.0",
+    "@anthropic-ai/sdk": "^0.96.0",
     "@aws-sdk/client-cloudwatch": "^3.1010.0",
     "@aws-sdk/client-ecs": "^3.1010.0",
     "@aws-sdk/client-s3": "^3.1014.0",
     "@aws-sdk/client-ssm": "^3.1010.0",
-    "aws-cdk-lib": "^2.170.0",
-    "constructs": "^10.4.2"
+    "aws-cdk-lib": "^2.254.0",
+    "constructs": "^10.5.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "@types/node": "^22.0.0",
-    "aws-cdk": "^2.170.0",
-    "esbuild": "^0.24.0",
+    "@types/source-map-support": "^0.5.10",
+    "aws-cdk": "^2.1121.0",
+    "esbuild": "^0.28.0",
     "jest": "^29.7.0",
+    "source-map-support": "^0.5.21",
     "ts-jest": "^29.1.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- run ECS agent/review tasks in private subnets by default, with a public subnet opt-in context flag
- centralize Fargate task launch config and .github/AGENT.md parsing
- require current human GitHub approval before auto-merge, while keeping bot review labels as signals
- split CI from release deployment and pin Docker runtime tools

## Validation
- npm run build
- npm test
- npm audit --json (infra and website)
- npm run synth
- bash -n agent shell entrypoints and deploy.sh
- npm ci in infra