### PR TITLE
docs: fix stale webhook-handler.ts line count, mark OpenRouter migration won't-fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ docker push $REPO_URI:latest
 
 ## Key Files
 
-- `infra/lib/webhook-handler.ts` - Main webhook handler (1400+ lines, handles all GitHub events)
+- `infra/lib/webhook-handler.ts` - Main webhook handler (~4,400 lines, handles all GitHub events)
 - `infra/lib/stack.ts` - CDK stack definition (Lambda, Fargate, VPC setup)
 - `agent/entrypoint.sh` - Wrapper script for Claude Code
 - `deploy.sh` - Deployment automation script

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -140,7 +140,8 @@ Drop the `files` field (may not be supported in all `gh` versions). Get the diff
 
 ## Phase 2 — Cut Costs, Add Memory (Week 3-4)
 
-### 2.1 Switch from OpenRouter to direct Anthropic API
+### 2.1 Switch from OpenRouter to direct Anthropic API — superseded, won't-fix
+**Status:** ARB decided won't-fix for the general migration (ADR #473, 2026-06-17). The narrower `call_llm_for_lint_fix()` accounting bypass that #473 does flag as must-fix is tracked separately, not here.
 **File:** `agent/entrypoint.sh` (3 env vars), `infra/lib/stack.ts` (SSM param)
 
 Current:


### PR DESCRIPTION
## Summary
Two doc-drift fixes flagged repeatedly in ARB weekly reviews (#395) without a fix landing — closing the loop instead of filing a fifth finding.

- **CLAUDE.md**: `webhook-handler.ts` listed as "1400+ lines." Actual count at `26d2e50` (current main) is 4,392. Flagged in ARB reviews weeks ending 05-27, 06-03, 06-10, 06-17.
- **ROADMAP.md §2.1**: Still listed the OpenRouter → direct Anthropic API migration as a live Phase 2.1 recommendation. ADR #473 (2026-06-17) ruled **won't-fix** on the general migration — only the `call_llm_for_lint_fix()` accounting bypass is must-fix, and that's tracked separately. An accepted ADR contradicting an unmaintained roadmap doc is exactly the kind of code/doc drift this review exists to catch.

## Note on CI
Main CI has had zero runs since 2026-06-09 (15 days, per #395 discussion) — last run was the "refresh infra lockfile" failure. This PR can't get a green check until that's fixed; flagging so reviewers don't read a stuck "pending" as this PR's fault.

## Test plan
- [x] Diff is two doc-only line changes, no code paths touched
- [ ] N/A — no executable change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cenetex/agent#395

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4GjKRZVX3ieyRYGhEacRx)_